### PR TITLE
Fix ignoring unix socket connect params

### DIFF
--- a/fmpm.cpp
+++ b/fmpm.cpp
@@ -421,15 +421,11 @@ int main(int argc, char **argv)
         snprintf(connectParams.addressInfo, MAX_PATH_LEN, "%s", mUnixSockPath);
         connectParams.addressIsUnixSocket = 1;
     }
-    if ( strnlen(mHostname, MAX_PATH_LEN) > 0 )
+    else if ( strnlen(mHostname, MAX_PATH_LEN) > 0 )
     {
         snprintf(connectParams.addressInfo, MAX_PATH_LEN, "%s", mHostname);
         connectParams.addressIsUnixSocket = 0;
     }
-
-
-    strncpy(connectParams.addressInfo, mHostname, sizeof(mHostname));
-    connectParams.addressIsUnixSocket = 0;
 
     fmReturn = fmConnect(&connectParams, &fmHandle);
     if (fmReturn != FM_ST_SUCCESS){


### PR DESCRIPTION
This change fixes the connection to the Fabric Manager (FM) flow always using TCP, instead of the UNIX socket when specified. 

Before this change, when FM was configured to listen to a [UNIX socket](https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/index.html#the-fabric-manager-domain-socket-interface) (i.e. run with the `UNIX_SOCKET_PATH=<socket_path>` and `FM_CMD_UNIX_SOCKET_PATH=<socket_path>` configuration options), `fmpm` would fail to connect to the FM instance as it would try to use TCP:

```shell
$ fmpm --unix-domain-flow <socket_path> -l
Failed to connect to Fabric Manager instance.
```

After this change:

```shell
fmpm --unix-domain-socket <socket_path> -l
{
   "maxNumPartitions" : 15,
   "numPartitions" : 15,
   "partitionInfo" : [
      {
      ...
      }]
}