### PR TITLE
fix: correct pointer increment and set proper addressType

### DIFF
--- a/fmpm.cpp
+++ b/fmpm.cpp
@@ -52,7 +52,7 @@ parsePartitionIdlistString(std::string & partitionListStr, unsigned int * partit
         haveSeen[partId] = 1;
 
         partitionIds[*numPartitions] = partId;
-        *numPartitions++;
+        (*numPartitions)++;
 
         token = strtok(NULL, ",");
     }
@@ -420,11 +420,13 @@ int main(int argc, char **argv)
     {
         snprintf(connectParams.addressInfo, MAX_PATH_LEN, "%s", mUnixSockPath);
         connectParams.addressIsUnixSocket = 1;
+		connectParams.addressType = NV_FM_API_ADDR_TYPE_UNIX;
     }
     if ( strnlen(mHostname, MAX_PATH_LEN) > 0 )
     {
         snprintf(connectParams.addressInfo, MAX_PATH_LEN, "%s", mHostname);
         connectParams.addressIsUnixSocket = 0;
+		connectParams.addressType = NV_FM_API_ADDR_TYPE_INET;
     }
 
 


### PR DESCRIPTION
The previous implementation incorrectly used post-increment on a pointer address instead of the integer value, this was causing pointer address increment instead of incrementing the value stored. This was causing incorrect number of partitions i.e. `zero` in `fmActivatedFabricPartitionList_t::numPartitions`  sent to `fmSetActivatedFabricPartitions` API.

Also set correct addressType for connection parameters.