### PR TITLE
fix: honour --unix-domain-socket when it is passed to fmpm

### DIFF
--- a/fmpm.cpp
+++ b/fmpm.cpp
@@ -421,17 +421,11 @@ int main(int argc, char **argv)
         snprintf(connectParams.addressInfo, MAX_PATH_LEN, "%s", mUnixSockPath);
         connectParams.addressIsUnixSocket = 1;
 		connectParams.addressType = NV_FM_API_ADDR_TYPE_UNIX;
-    }
-    if ( strnlen(mHostname, MAX_PATH_LEN) > 0 )
-    {
+    } else if ( strnlen(mHostname, MAX_PATH_LEN) > 0 ) {
         snprintf(connectParams.addressInfo, MAX_PATH_LEN, "%s", mHostname);
         connectParams.addressIsUnixSocket = 0;
 		connectParams.addressType = NV_FM_API_ADDR_TYPE_INET;
     }
-
-
-    strncpy(connectParams.addressInfo, mHostname, sizeof(mHostname));
-    connectParams.addressIsUnixSocket = 0;
 
     fmReturn = fmConnect(&connectParams, &fmHandle);
     if (fmReturn != FM_ST_SUCCESS){


### PR DESCRIPTION
Fixes the issue where `addressIsUnixSocket` is always overriden, even when `--unix-domain-socket` argument is supplied.