### PR TITLE
Fix duplicate partition ID parsing hang

### DIFF
--- a/fmpm.cpp
+++ b/fmpm.cpp
@@ -47,12 +47,13 @@ parsePartitionIdlistString(std::string & partitionListStr, unsigned int * partit
             return FM_ST_BADPARAM;
         }
 
-        if ( haveSeen[partId] )
-            continue; /* Just ignore it and move on */
-        haveSeen[partId] = 1;
+        if ( !haveSeen[partId] )
+        {
+            haveSeen[partId] = 1;
 
-        partitionIds[*numPartitions] = partId;
-        (*numPartitions)++;
+            partitionIds[*numPartitions] = partId;
+            (*numPartitions)++;
+        }
 
         token = strtok(NULL, ",");
     }


### PR DESCRIPTION
parsePartitionIdlistString ignored duplicate partition IDs with a continue before advancing the strtok tokenizer. When --set-activated-list contained a repeated valid ID such as 5,5, the loop kept reprocessing the same token forever and pinned the caller.

Keep the existing behavior of ignoring duplicates, but only append unseen IDs and always fall through to the tokenizer advance at the end of the loop body.