### PR TITLE
fix: Makefile uses Unicode division slash instead of ASCII in system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-IDIR := ∕usr∕include
+IDIR := /usr/include
 CXXFLAGS = -I $(IDIR) $(shell pkg-config --cflags jsoncpp)
 
-LDIR := ∕usr∕lib
+LDIR := /usr/lib
 LDFLAGS= -L$(LDIR) -lnvfm -ljsoncpp
 
 fmpm: fmpm.o


### PR DESCRIPTION
### Problem
Makefile uses Unicode division slash instead of ASCII in system paths

### Fix
Replace:
```
IDIR := ∕usr∕include
CXXFLAGS = -I $(IDIR) $(shell pkg-config --cflags jsoncpp)

LDIR := ∕usr∕lib
LDFLAGS= -L$(LDIR) -lnvfm -ljsoncpp
```

with:
```
IDIR := /usr/include
CXXFLAGS = -I $(IDIR) $(shell pkg-config --cflags jsoncpp)

LDIR := /usr/lib
LDFLAGS= -L$(LDIR) -lnvfm -ljsoncpp
```

### Files changed
- `Makefile`