### PR TITLE
fix: connectParams unconditionally overwritten after socket/hostname

### DIFF
--- a/fmpm.cpp
+++ b/fmpm.cpp
@@ -423,16 +423,12 @@ int main(int argc, char **argv)
         connectParams.addressIsUnixSocket = 1;
 		connectParams.addressType = NV_FM_API_ADDR_TYPE_UNIX;
     }
-    if ( strnlen(mHostname, MAX_PATH_LEN) > 0 )
+    else if ( strnlen(mHostname, MAX_PATH_LEN) > 0 )
     {
         snprintf(connectParams.addressInfo, MAX_PATH_LEN, "%s", mHostname);
         connectParams.addressIsUnixSocket = 0;
 		connectParams.addressType = NV_FM_API_ADDR_TYPE_INET;
     }
-
-
-    strncpy(connectParams.addressInfo, mHostname, sizeof(mHostname));
-    connectParams.addressIsUnixSocket = 0;
 
     fmReturn = fmConnect(&connectParams, &fmHandle);
     if (fmReturn != FM_ST_SUCCESS){


### PR DESCRIPTION
### Problem
connectParams unconditionally overwritten after socket/hostname setup

### Fix
Replace:
```
    memset(connectParams.addressInfo, 0, sizeof(connectParams.addressInfo));
    if ( strnlen(mUnixSockPath, MAX_PATH_LEN) > 0 )
    {
        snprintf(connectParams.addressInfo, MAX_PATH_LEN, "%s", mUnixSockPath);
        connectParams.addressIsUnixSocket = 1;
		connectParams.addressType = NV_FM_API_ADDR_TYPE_UNIX;
    }
    if ( strnlen(mHostname, MAX_PATH_LEN) > 0 )
    {
        snprintf(connectParams.addressInfo, MAX_PATH_LEN, "%s", mHostname);
        connectParams.addressIsUnixSocket = 0;
		connectParams.addressType = NV_FM_API_ADDR_TYPE_INET;
    }


    strncpy(connectParams.addressInfo, mHostname, sizeof(mHostname));
    connectParams.addressIsUnixSocket = 0;
```

with:
```
    memset(connectParams.addressInfo, 0, sizeof(connectParams.addressInfo));
    if ( strnlen(mUnixSockPath, MAX_PATH_LEN) > 0 )
    {
        snprintf(connectParams.addressInfo, MAX_PATH_LEN, "%s", mUnixSockPath);
        connectParams.addressIsUnixSocket = 1;
		connectParams.addressType = NV_FM_API_ADDR_TYPE_UNIX;
    }
    else if ( strnlen(mHostname, MAX_PATH_LEN) > 0 )
    {
        snprintf(connectParams.addressInfo, MAX_PATH_LEN, "%s", mHostname);
        connectParams.addressIsUnixSocket = 0;
		connectParams.addressType = NV_FM_API_ADDR_TYPE_INET;
    }
```

### Files changed
- `fmpm.cpp`