### PR TITLE
fix: strtok writes into const string buffer from c_str()

### DIFF
--- a/fmpm.cpp
+++ b/fmpm.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <string.h>
+#include <vector>
 #include <json/json.h>
 #include "nv_fm_agent.h"
 
@@ -32,7 +33,8 @@ typedef enum SharedFabricCmdEnum
 fmReturn_t
 parsePartitionIdlistString(std::string & partitionListStr, unsigned int * partitionIds, unsigned * numPartitions)
 {
-    char * token = strtok((char *)partitionListStr.c_str(), ",");
+    std::vector<char> mutableCopy(partitionListStr.c_str(), partitionListStr.c_str() + partitionListStr.length() + 1);
+    char * token = strtok(mutableCopy.data(), ",");
     int haveSeen[FM_MAX_FABRIC_PARTITIONS] = { 0 };
 
     *numPartitions = 0;


### PR DESCRIPTION
This PR addresses the following issue in `fmpm.cpp`: strtok writes into const string buffer from c_str().

## Changes
- `fmpm.cpp`: strtok writes into const string buffer from c_str().

## Details
```diff
--- a/fmpm.cpp
+++ b/fmpm.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <string.h>
+#include <vector>
 #include <json/json.h>
 #include "nv_fm_agent.h"
 
@@ -40,7 +41,8 @@
 fmReturn_t
 parsePartitionIdlistString(std::string & partitionListStr, unsigned int * partitionIds, unsigned * numPartitions)
 {
-    char * token = strtok((char *)partitionListStr.c_str(), ",");
+    std::vector<char> mutableCopy(partitionListStr.c_str(), partitionListStr.c_str() + partitionListStr.length() + 1);
+    char * token = strtok(mutableCopy.data(), ",");
     int haveSeen[FM_MAX_FABRIC_PARTITIONS] = { 0 };
```

## Tests

> Let me know if you want tests added for this fix or not.