### PR TITLE
fix: --unix-domain-socket address overwritten by hostname

### DIFF
--- a/fmpm.cpp
+++ b/fmpm.cpp
@@ -423,16 +423,12 @@ int main(int argc, char **argv)
         connectParams.addressIsUnixSocket = 1;
 		connectParams.addressType = NV_FM_API_ADDR_TYPE_UNIX;
     }
-    if ( strnlen(mHostname, MAX_PATH_LEN) > 0 )
+    else if ( strnlen(mHostname, MAX_PATH_LEN) > 0 )
     {
         snprintf(connectParams.addressInfo, MAX_PATH_LEN, "%s", mHostname);
         connectParams.addressIsUnixSocket = 0;
 		connectParams.addressType = NV_FM_API_ADDR_TYPE_INET;
     }
-
-
-    strncpy(connectParams.addressInfo, mHostname, sizeof(mHostname));
-    connectParams.addressIsUnixSocket = 0;
 
     fmReturn = fmConnect(&connectParams, &fmHandle);
     if (fmReturn != FM_ST_SUCCESS){


### PR DESCRIPTION
This PR addresses the following issue in `fmpm.cpp`: --unix-domain-socket address overwritten by hostname.

## Changes
- `fmpm.cpp`: --unix-domain-socket address overwritten by hostname.

## Details
```diff
--- a/fmpm.cpp
+++ b/fmpm.cpp
@@ -1,16 +1,12 @@
-    if ( strnlen(mUnixSockPath, MAX_PATH_LEN) > 0 )
-    {
-        snprintf(connectParams.addressInfo, MAX_PATH_LEN, "%s", mUnixSockPath);
-        connectParams.addressIsUnixSocket = 1;
-		connectParams.addressType = NV_FM_API_ADDR_TYPE_UNIX;
-    }
-    if ( strnlen(mHostname, MAX_PATH_LEN) > 0 )
-    {
-        snprintf(connectParams.addressInfo, MAX_PATH_LEN, "%s", mHostname);
-        connectParams.addressIsUnixSocket = 0;
-		connectParams.addressType = NV_FM_API_ADDR_TYPE_INET;
-    }
-
-
-    strncpy(connectParams.addressInfo, mHostname, sizeof(mHostname));
-    connectParams.addressIsUnixSocket = 0;
+    if ( strnlen(mUnixSockPath, MAX_PATH_LEN) > 0 )
+    {
+        snprintf(connectParams.addressInfo, MAX_PATH_LEN, "%s", mUnixSockPath);
+        connectParams.addressIsUnixSocket = 1;
+		connectParams.addressType = NV_FM_API_ADDR_TYPE_UNIX;
+    }
+    else if ( strnlen(mHostname, MAX_PATH_LEN) > 0 )
+    {
+        snprintf(connectParams.addressInfo, MAX_PATH_LEN, "%s", mHostname);
+        connectParams.addressIsUnixSocket = 0;
+		connectParams.addressType = NV_FM_API_ADDR_TYPE_INET;
+    }
```

## Tests

> Let me know if you want tests added for this fix or not.