### PR TITLE
fix: connectParams struct is not zero-initialized

### DIFF
--- a/fmpm.cpp
+++ b/fmpm.cpp
@@ -413,6 +413,7 @@ int main(int argc, char **argv)
 
     /* Connect to Fabric Manager instance */
     fmConnectParams_t connectParams;
+    memset(&connectParams, 0, sizeof(connectParams));
     connectParams.timeoutMs = 1000; // in milliseconds
     connectParams.version = fmConnectParams_version;
 


### PR DESCRIPTION
This PR addresses the following issue in `fmpm.cpp`: connectParams struct is not zero-initialized.

## Changes
- `fmpm.cpp`: connectParams struct is not zero-initialized.

## Details
```diff
--- a/fmpm.cpp
+++ b/fmpm.cpp
@@ -1,4 +1,5 @@
-    /* Connect to Fabric Manager instance */
-    fmConnectParams_t connectParams;
-    connectParams.timeoutMs = 1000; // in milliseconds
-    connectParams.version = fmConnectParams_version;
+    /* Connect to Fabric Manager instance */
+    fmConnectParams_t connectParams;
+    memset(&connectParams, 0, sizeof(connectParams));
+    connectParams.timeoutMs = 1000; // in milliseconds
+    connectParams.version = fmConnectParams_version;
```

## Tests

> Let me know if you want tests added for this fix or not.