### PR TITLE
fix: -d option skips partition ID range validation

### DIFF
--- a/fmpm.cpp
+++ b/fmpm.cpp
@@ -359,6 +359,10 @@ int main(int argc, char **argv)
                 std::cerr << "Error: -d option requires partition ID." << std::endl;
                 return FM_ST_BADPARAM;
             }
+            if ( partitionId >= FM_MAX_FABRIC_PARTITIONS ) {
+                std::cout << "Invalid Partition ID." << std::endl;
+                return FM_ST_BADPARAM;
+            }
         } else if (std::string(argv[i]) == "--set-activated-list") {
             operation = SHARED_FABRIC_CMD_SET_ACTIVATED_PARTITION_LIST;
             if (i + 1 < argc) {


### PR DESCRIPTION
This PR addresses the following issue in `fmpm.cpp`: -d option skips partition ID range validation.

## Changes
- `fmpm.cpp`: -d option skips partition ID range validation.

## Details
```diff
--- a/fmpm.cpp
+++ b/fmpm.cpp
@@ -1,10 +1,14 @@
-        } else if (std::string(argv[i]) == "-d") {
-            operation = SHARED_FABRIC_CMD_DEACTIVATE_PARTITION;
-            if (i + 1 < argc) {
-                partitionId = std::stoul(argv[i + 1]);
-                ++i;
-            } else {
-                std::cerr << "Error: -d option requires partition ID." << std::endl;
-                return FM_ST_BADPARAM;
-            }
-        } else if (std::string(argv[i]) == "--set-activated-list") {
+        } else if (std::string(argv[i]) == "-d") {
+            operation = SHARED_FABRIC_CMD_DEACTIVATE_PARTITION;
+            if (i + 1 < argc) {
+                partitionId = std::stoul(argv[i + 1]);
+                ++i;
+            } else {
+                std::cerr << "Error: -d option requires partition ID." << std::endl;
+                return FM_ST_BADPARAM;
+            }
+            if ( partitionId >= FM_MAX_FABRIC_PARTITIONS ) {
+                std::cout << "Invalid Partition ID." << std::endl;
+                return FM_ST_BADPARAM;
+            }
+        } else if (std::string(argv[i]) == "--set-activated-list") {
```

## Tests

> Let me know if you want tests added for this fix or not.