### PR TITLE
fix: partition ID printf uses wrong format specifier

### DIFF
--- a/fmpm.cpp
+++ b/fmpm.cpp
@@ -43,7 +43,7 @@ parsePartitionIdlistString(std::string & partitionListStr, unsigned int * partit
 
         if ( partId < 0 || partId >= FM_MAX_FABRIC_PARTITIONS )
         {
-            printf("Invalid partition Id %u was given.\n", partId);
+            printf("Invalid partition Id %d was given.\n", partId);
             return FM_ST_BADPARAM;
         }
 


### PR DESCRIPTION
I am fairly sure this PR is correct, if not let me know. This PR addresses the following issue in `fmpm.cpp`: partition ID printf uses wrong format specifier.

## Changes
- `fmpm.cpp`: partition ID printf uses wrong format specifier.

## Details
```diff
--- a/fmpm.cpp
+++ b/fmpm.cpp
@@ -1,1 +1,1 @@
-            printf("Invalid partition Id %u was given.\n", partId);
+            printf("Invalid partition Id %d was given.\n", partId);
```

## Tests

> Let me know if you want tests added for this fix or not.