### PR TITLE
fix: NVLink error message missing verb

### DIFF
--- a/fmpm.cpp
+++ b/fmpm.cpp
@@ -232,7 +232,7 @@ getNvlinkFailedDevices(fmHandle_t fmHandle)
     fmReturn = fmGetNvlinkFailedDevices(fmHandle, &nvlinkFailedDevice);
     if ( fmReturn != FM_ST_SUCCESS )
     {
-        std::cout << "Failed to NVLink failed devices. fmReturn: " << fmReturn << std::endl;
+        std::cout << "Failed to get NVLink failed devices. fmReturn: " << fmReturn << std::endl;
         return fmReturn;
     }
 


### PR DESCRIPTION
This PR addresses the following issue in `fmpm.cpp`: NVLink error message missing verb.

## Changes
- `fmpm.cpp`: NVLink error message missing verb.

## Details
```diff
--- a/fmpm.cpp
+++ b/fmpm.cpp
@@ -1,1 +1,1 @@
-        std::cout << "Failed to NVLink failed devices. fmReturn: " << fmReturn << std::endl;
+        std::cout << "Failed to get NVLink failed devices. fmReturn: " << fmReturn << std::endl;
```

## Tests

> Let me know if you want tests added for this fix or not.